### PR TITLE
Add Codable support

### DIFF
--- a/Sources/Partial/Partial+Encodable.swift
+++ b/Sources/Partial/Partial+Encodable.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol PartialCodable: Codable {
+    associatedtype CodingKey: Swift.CodingKey
+
+    static func encodeValue(_ value: Any, for keyPath: PartialKeyPath<Self>, to container: inout KeyedEncodingContainer<CodingKey>) throws
+}

--- a/Sources/Partial/Partial.swift
+++ b/Sources/Partial/Partial.swift
@@ -3,7 +3,6 @@ import Foundation
 /// A struct that mirrors the properties of `Wrapped`, making each of the
 /// types optional.
 public struct Partial<Wrapped>: PartialProtocol, CustomStringConvertible {
-
     /// An error that can be thrown by the `value(for:)` function.
     public enum Error<Value>: Swift.Error {
         /// The key path has not been set.
@@ -16,7 +15,7 @@ public struct Partial<Wrapped>: PartialProtocol, CustomStringConvertible {
     }
 
     /// The values that have been set.
-    private var values: [PartialKeyPath<Wrapped>: Any] = [:]
+    fileprivate var values: [PartialKeyPath<Wrapped>: Any] = [:]
 
     /// Create an empty `Partial`.
     public init() {}
@@ -51,5 +50,16 @@ public struct Partial<Wrapped>: PartialProtocol, CustomStringConvertible {
     public mutating func removeValue<Value>(for keyPath: KeyPath<Wrapped, Value>) {
         values.removeValue(forKey: keyPath)
     }
+}
 
+extension Partial: Encodable where Wrapped: PartialCodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Wrapped.CodingKey.self)
+
+        try values.forEach { pair in
+            let (keyPath, value) = pair
+
+            try Wrapped.encodeValue(value, for: keyPath, to: &container)
+        }
+    }
 }

--- a/Tests/PartialTests/Tests/PartialCodableTests.swift
+++ b/Tests/PartialTests/Tests/PartialCodableTests.swift
@@ -1,0 +1,70 @@
+import Quick
+import Nimble
+import Foundation
+
+@testable
+import Partial
+
+final class PartialCodableTests: QuickSpec {
+    override func spec() {
+        describe("PartialCodable") {
+            struct CodableType: Codable, PartialCodable, Hashable {
+                static func encodeValue(
+                    _ value: Any,
+                    for keyPath: PartialKeyPath<CodableType>,
+                    to container: inout KeyedEncodingContainer<CodingKeys>
+                ) throws {
+                    switch keyPath {
+                    case \Self.foo:
+                        try container.encode(value as! String, forKey: .foo)
+                    case \Self.bar:
+                        try container.encode(value as! Int, forKey: .bar)
+                    default:
+                        break
+                    }
+                }
+
+                let foo: String
+                let bar: Int
+            }
+
+            var partial: Partial<CodableType>!
+
+            beforeEach {
+                partial = Partial()
+            }
+
+            context("with complete value") {
+                beforeEach {
+                    partial.foo = "foo"
+                    partial.bar = 123
+                }
+
+                context("the encoded data") {
+                    var encodedData: Data!
+
+                    beforeEach {
+                        let encoder = JSONEncoder()
+                        encodedData = try? encoder.encode(partial)
+                    }
+
+                    it("should not be nil") {
+                        expect(encodedData).toNot(beNil())
+                    }
+
+                    it("should be usable to decode Wrapped") {
+                        do {
+                            let decoder = JSONDecoder()
+                            let decodedValue = try decoder.decode(CodableType.self, from: encodedData)
+
+                            expect(decodedValue.foo) == "foo"
+                            expect(decodedValue.bar) == 123
+                        } catch {
+                            fail("Should not throw: \(error)")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I like that the `Wrapped` type itself is conforming to `PartialCodable` and it doesn't require any new types to be created by the consumer.

I would like a way to ask the `PartialCodable` to return the expected type for a given `PartialKeyPath<Self>` to avoid `switch` that's currently required, and hopefully remove the force casts. I think this would require the return value to be `some Codable` and that would bump the OS requirement and might not even work since it's not returning a concrete type.

## TODO

- [ ] Find a more appropriate name for `PartialCodable`
- [ ] Add `Decodable` support